### PR TITLE
Fixed the calculation for the first argument of select()

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -69,7 +69,7 @@ impl FdSet {
 }
 
 pub fn select(read: &mut FdSet, write: &mut FdSet, except: &mut FdSet) -> io::Result<usize> {
-    let nfds = cmp::max(read.max_fd, write.max_fd);
+    let nfds = cmp::max(cmp::max(read.max_fd, write.max_fd), except.max_fd) + 1;
 
     let read_fd = match read.max_fd {
         0 => ptr::null_mut(),
@@ -107,7 +107,7 @@ pub fn select_timeout(read: &mut FdSet, write: &mut FdSet, except: &mut FdSet, t
         tv_usec: timeout.subsec_micros() as _,
     };
 
-    let nfds = cmp::max(read.max_fd, write.max_fd) + 1;
+    let nfds = cmp::max(cmp::max(read.max_fd, write.max_fd), except.max_fd) + 1;
 
     let read_fd = match read.max_fd {
         0 => ptr::null_mut(),

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,7 +1,11 @@
 use selecting::Selector;
 
-use std::io::{self, Read};
-use std::net::TcpStream;
+use std::thread::{self, sleep};
+
+use std::io::{self, Read, Write};
+use std::net::{TcpStream, TcpListener, Shutdown};
+use std::os::fd::AsRawFd;
+use std::time::Duration;
 
 #[test]
 pub fn should_work_tcp_stream() {
@@ -27,4 +31,54 @@ pub fn should_work_tcp_stream() {
     assert_eq!(result.len(), 1);
     assert!(!result.is_read(&stream));
     assert!(result.is_write(&stream));
+}
+
+#[test]
+pub fn should_work_with_multiple_fds() {
+    let mut selector = Selector::new();
+
+    let server = thread::spawn(|| {
+        let listener = TcpListener::bind("localhost:1234").expect("Couldn't bind to the address...");
+        let s1 = listener.accept().expect("Couldn't accept the connection...").0;
+        let mut s2 = listener.accept().expect("Couldn't accept the connection...").0;
+        let mut s3 = listener.accept().expect("Couldn't accept the connection...").0;
+
+        s1.set_nonblocking(true).expect("set_nonblocking call failed");
+        s2.set_nonblocking(true).expect("set_nonblocking call failed");
+        s3.set_nonblocking(true).expect("set_nonblocking call failed");
+
+        s2.write(b"Hello from s2").expect("Couldn't write to the socket...");
+        s3.write(b"Hello from s3").expect("Couldn't write to the socket...");
+
+        sleep(Duration::from_millis(100));
+
+        s1.shutdown(Shutdown::Both).expect("Couldn't shutdown the socket...");
+        s2.shutdown(Shutdown::Both).expect("Couldn't shutdown the socket...");
+        s3.shutdown(Shutdown::Both).expect("Couldn't shutdown the socket...");
+    });
+
+    
+    let s1 = TcpStream::connect("localhost:1234").expect("Couldn't connect to the server...");
+    let s2 = TcpStream::connect("localhost:1234").expect("Couldn't connect to the server...");
+    let s3 = TcpStream::connect("localhost:1234").expect("Couldn't connect to the server...");
+    
+    s1.set_nonblocking(true).expect("set_nonblocking call failed");
+    s2.set_nonblocking(true).expect("set_nonblocking call failed");
+    s3.set_nonblocking(true).expect("set_nonblocking call failed");
+    
+    selector.add_read(&s1);
+    selector.add_read(&s2);
+    selector.add_read(&s3);
+    
+    println!("s1 fd: {}", s1.as_raw_fd());
+    println!("s2 fd: {}", s2.as_raw_fd());
+    println!("s3 fd: {}", s3.as_raw_fd());
+    
+    let result = selector.select().expect("To try select");
+    assert_eq!(result.len(), 2);
+    assert!(!result.is_read(&s1));
+    assert!(result.is_read(&s2));
+    assert!(result.is_read(&s3));
+
+    server.join().expect("Couldn't join the server thread...");
 }


### PR DESCRIPTION
## What did I do

- Fixed the calculation for the first argument of select()
- Added a test for case of multiple sockets

## Details

The `nfds` argument should be calculated as follows:

```plain
nfds = max(read_max_fd, write_max_fd, except_max_fd) + 1
```

## Reference:
- [select(2) - Linux manual page](https://man7.org/linux/man-pages/man2/select.2.html)