### PR TITLE
Fix tests & Restore ubuntu-latest in github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v1
@@ -41,3 +41,4 @@ jobs:
 
     - name: Test
       run: cargo test
+      timeout-minutes: 1

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -40,6 +40,8 @@ pub fn should_work_with_multiple_fds() {
     let (server_notifier, server_notification) = std::sync::mpsc::channel();
     let server = thread::spawn(move || {
         let listener = TcpListener::bind(LOCALHOST).expect("Couldn't bind to the address...");
+        // Notify the client that the server is ready
+        client_notifier.send(()).expect("send client notification");
         let s1 = listener.accept().expect("Couldn't accept the connection...").0;
         let mut s2 = listener.accept().expect("Couldn't accept the connection...").0;
         let mut s3 = listener.accept().expect("Couldn't accept the connection...").0;
@@ -51,7 +53,9 @@ pub fn should_work_with_multiple_fds() {
         s2.write(b"Hello from s2").expect("Couldn't write to the socket...");
         s3.write(b"Hello from s3").expect("Couldn't write to the socket...");
 
+        // Notify the client that the server has sent the data
         client_notifier.send(()).expect("send client notification");
+        // Wait for the client to receive the data
         server_notification.recv().expect("receive server notification");
 
         s1.shutdown(Shutdown::Both).expect("Couldn't shutdown the socket...");
@@ -59,6 +63,8 @@ pub fn should_work_with_multiple_fds() {
         s3.shutdown(Shutdown::Both).expect("Couldn't shutdown the socket...");
     });
 
+    // Wait for the server to start
+    client_notification.recv().expect("receive server notifcation");
     let s1 = TcpStream::connect(LOCALHOST).expect("Couldn't connect to the server...");
     let s2 = TcpStream::connect(LOCALHOST).expect("Couldn't connect to the server...");
     let s3 = TcpStream::connect(LOCALHOST).expect("Couldn't connect to the server...");
@@ -67,20 +73,30 @@ pub fn should_work_with_multiple_fds() {
     s2.set_nonblocking(true).expect("set_nonblocking call failed");
     s3.set_nonblocking(true).expect("set_nonblocking call failed");
 
+    // Wait for the server to send the data
     client_notification.recv().expect("receive server notifcation");
-    selector.add_read(&s1);
-    selector.add_read(&s2);
-    selector.add_read(&s3);
-    let result = selector.select().expect("To try select");
-    assert_eq!(result.len(), 2);
-    assert!(!result.is_read(&s1));
-    assert!(result.is_read(&s2));
-    assert!(result.is_read(&s3));
 
+    loop {
+        selector.add_read(&s1);
+        selector.add_read(&s2);
+        selector.add_read(&s3);
+        let result = selector.select().expect("To try select");
+        selector.clear_read();
+        let len = result.len();
+        assert!(len <= 2);
+        if len == 2 {
+            break;
+        }
+    }
+
+    // Notify the server that the client has received the data
     server_notifier.send(()).expect("send server notifcation");
 
     server.join().expect("Couldn't join the server thread...");
 
+    selector.add_read(&s1);
+    selector.add_read(&s2);
+    selector.add_read(&s3);
     let result = selector.select().expect("To try select");
     //Shutdown should trigger read
     assert_eq!(result.len(), 3);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -76,12 +76,11 @@ pub fn should_work_with_multiple_fds() {
     // Wait for the server to send the data
     client_notification.recv().expect("receive server notifcation");
 
+    selector.add_read(&s1);
+    selector.add_read(&s2);
+    selector.add_read(&s3);
     loop {
-        selector.add_read(&s1);
-        selector.add_read(&s2);
-        selector.add_read(&s3);
         let result = selector.select().expect("To try select");
-        selector.clear_read();
         let len = result.len();
         assert!(len <= 2);
         if len == 2 {
@@ -94,9 +93,6 @@ pub fn should_work_with_multiple_fds() {
 
     server.join().expect("Couldn't join the server thread...");
 
-    selector.add_read(&s1);
-    selector.add_read(&s2);
-    selector.add_read(&s3);
     let result = selector.select().expect("To try select");
     //Shutdown should trigger read
     assert_eq!(result.len(), 3);


### PR DESCRIPTION
- related: #1
- test: Fix tests (now tests run successfully on my computer over 200 times!)
- actions: Undo removing 'ubuntu-latest'
- actions: Add timeout
